### PR TITLE
docs: Fix grammar issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides a Solana-compatible JSON-RPC and websocket endpoint.
 
 All transactions sent to the RPC node will be forwarded to our sequencer.
 
-Once the sequencer processed those transactions, they would be sent back to the RPC node by a message bus (Redis for now), the RPC node would replay the transaction to make sure that the sequencer is not malicious.
+Once the sequencer processes those transactions, they will be sent back to the RPC node by a message bus (Redis for now), the RPC node would replay the transaction to make sure that the sequencer is not malicious.
 
 ### Machine spec:
 


### PR DESCRIPTION
A grammatical inconsistency in the documentation. The sentence:  

> "Once the sequencer processed those transactions, they would be sent back..."  

has been corrected to:  

> "Once the sequencer processes those transactions, they will be sent back..."  

This keeps the tense consistent and properly aligns with the intended meaning. Let me know if any other improvements are needed!